### PR TITLE
Bug fix on null keys!

### DIFF
--- a/server/utils/responseUtils.js
+++ b/server/utils/responseUtils.js
@@ -5,7 +5,7 @@
 import {BigNumber} from "ethers";
 
 function removeDecimalUnderscoreFromObject(obj) {
-    if (typeof obj === "object") {
+    if (typeof obj === "object" && obj !== null) {
         if (obj["_decimals"]) {
             obj["decimals"] = obj["_decimals"];
             delete obj["_decimals"];


### PR DESCRIPTION
In `removeDecimalUnderscoreFromObject` function, if the input is null the function throws exception because null is an object type! 
Since this is a recursive function, it happens in a few cases when inner keys of an object are null. 
[Requesting for Fantom stable swap pools](https://syn-api-x.herokuapp.com/v1/get_stableswap_pools?chain=250) is a sample scenario with exception.